### PR TITLE
Output score file for regression directly.

### DIFF
--- a/src/main/scala/org/phenoscape/owl/build/RunPairwiseOWLSim.scala
+++ b/src/main/scala/org/phenoscape/owl/build/RunPairwiseOWLSim.scala
@@ -17,7 +17,8 @@ object RunPairwiseOWLSim extends App {
   val ontfile = new File(args(2))
   val profilesFile = new File(args(3))
   val corpus = args(4)
-  val outfile = args(5)
+  val triplesOutfile = args(5)
+  val tsvOutfile = args(6)
 
   val manager = OWLManager.createOWLOntologyManager()
   val ontology = manager.loadOntologyFromOntologyDocument(ontfile)
@@ -39,6 +40,6 @@ object RunPairwiseOWLSim extends App {
   val startIndex = (taskNum - 1) * groupSize
   val group = orderedProfiles.drop(startIndex).take(groupSize)
   println("Computing similarity matrix")
-  owlSim.computeAllSimilarityToCorpusDirectOutput(group.toSet, new File(outfile))
+  owlSim.computeAllSimilarityToCorpusDirectOutput(group.toSet, new File(triplesOutfile), new File(tsvOutfile))
   println("Done: " + new Date())
 }


### PR DESCRIPTION
This information is all available during the similarity calculation, so we don't need to query it later, which is taking too long and too much memory. We will need to update the pipeline makefile.